### PR TITLE
mconfig: do not error out on missing cryptsetup

### DIFF
--- a/mlocal/checks/project-post.chk
+++ b/mlocal/checks/project-post.chk
@@ -366,7 +366,6 @@ if test "${host}" = "unix" ; then
       echo
       echo "unable to find the cryptsetup program, is the package cryptsetup-bin installed?"
       echo
-      exit 2
    else
       echo "yes"
    fi


### PR DESCRIPTION
I noticed I cannot build current singularity without having cryptsetup installed.
Looking at the places it is used, I see graceful handling of an incompatible
cryptsetup with runtime errors. Therefore, it is unnecessary to prevent a
build of singularity if no cryptsetup is present: It is optional functionality which
is checked at run-time anyway.

I have an environment where users won't be able to use cryptsetup anyway. I
only install the minimally needed software into the OS image. Please consider
something along this commit to enable builds of singularity without cryptsetup.

I just omitted the exit on missing cryptsetup from mconfig. I got a build out of
that that seems to be working. I don't know if there are further changes needed
for a smooth experience in the actual cryptsetup-related code.



Attn: @singularity-maintainers

